### PR TITLE
Stop using deprecated ActiveStorage::Current.host method

### DIFF
--- a/lib/active_storage/service/database_service.rb
+++ b/lib/active_storage/service/database_service.rb
@@ -107,7 +107,11 @@ module ActiveStorage
     end
 
     def current_host
-      ActiveStorage::Current.host
+      if ActiveStorage::Current.respond_to?(:url_options)
+        ActiveStorage::Current.url_options[:host]
+      else
+        ActiveStorage::Current.host
+      end
     end
   end
 end


### PR DESCRIPTION
`ActiveStorage::Current.host` is deprecated in favor of `ActiveStorage::Current.url_options`. In order to keep backwards compatibility, this change checks whether the `#url_options` method is available and uses that. Otherwise, it uses the older `#host` method.

This resolves #17.