### PR TITLE
Make database service work with Active Storage variants.

### DIFF
--- a/app/controllers/active_storage/database_controller.rb
+++ b/app/controllers/active_storage/database_controller.rb
@@ -10,13 +10,14 @@ class ActiveStorage::DatabaseController < ActiveStorage::BaseController
       # filename = key[:disposition].match(/filename=(\"?)(.+)\1/)[2]
       # Filename and content length can be determined w/o retrieving blob record given that the entire file will be
       # read into memory (via database_service.download).  Anticipating future feature of streaming.
-      blob = ActiveStorage::Blob.find_by!(key: key[:key])
+      # Note that a blob record may not be present for variants.
+      blob = ActiveStorage::Blob.find_by(key: key[:key])
 
       serve_file(
         key[:key],
         service: database_service(key[:service_name]),
         last_modified: key[:created_at],
-        content_length: blob.byte_size,
+        content_length: blob&.byte_size,
         content_type: key[:content_type],
         disposition: key[:disposition]
       )

--- a/lib/active_storage/service/database_service.rb
+++ b/lib/active_storage/service/database_service.rb
@@ -18,7 +18,7 @@ module ActiveStorage
         record = ::ActiveStorageDatum.find_by_key(key)
         if record
           if block_given?
-            yield record.id
+            yield record.io
           end
           return record.io
         else

--- a/lib/active_storage/service/database_service.rb
+++ b/lib/active_storage/service/database_service.rb
@@ -17,6 +17,9 @@ module ActiveStorage
       instrument :download, key: key do
         record = ::ActiveStorageDatum.find_by_key(key)
         if record
+          if block_given?
+            yield record.id
+          end
           return record.io
         else
           raise ActiveStorage::FileNotFoundError


### PR DESCRIPTION
Also closes #8.

ActiveStorage [passes a block to `download` when processing a variant](https://github.com/rails/rails/blob/3dd5d4900d01c0b25f44c2fbf6ce261d367a490a/activestorage/lib/active_storage/downloader.rb#L32). This doesn't work as `ActiveStorage::ActiveStorage::DatabaseService#download` currently doesn't accepts a block. This PR fixes that.
In addition, this PR also fixes an issue with downloading variants as `ActiveStorage::Blob` record may not be found by the variant key.