### PR TITLE
Fix looking up key with Rails 7.1+ config

### DIFF
--- a/app/controllers/active_storage/database_controller.rb
+++ b/app/controllers/active_storage/database_controller.rb
@@ -7,6 +7,8 @@ class ActiveStorage::DatabaseController < ActiveStorage::BaseController
 
   def show
     if key = decode_verified_key
+      key = key.with_indifferent_access
+
       # filename = key[:disposition].match(/filename=(\"?)(.+)\1/)[2]
       # Filename and content length can be determined w/o retrieving blob record given that the entire file will be
       # read into memory (via database_service.download).  Anticipating future feature of streaming.


### PR DESCRIPTION
In Rails 7.0 or below config, the decoded key is a hash with symbol keys. With Rails 7.1+, the default config changed serialization.

So when we upgraded our config to:

```ruby
    config.load_defaults 7.1
```

It caused the following error when trying to look up assets (because the gem's code is expecting symbol keys, so it passed a nil value along):

```
NoMethodError (undefined method `to_sym' for nil:NilClass):

activestorage (7.1.5.1) lib/active_storage/service/registry.rb:11:in `fetch'
activestorage-database-service (b18a63b2fef7) app/controllers/active_storage/database_controller.rb:45:in `database_service'
activestorage-database-service (b18a63b2fef7) app/controllers/active_storage/database_controller.rb:18:in `show'
...
```

---

For more info, can see https://railsdocs.org/guides/release_notes/upgrading_ruby_on_rails#new-codeactivesupportmessageverifiercode-default-serializer

I think this is the relevant section in the generated `config/initializers/new_framework_defaults_7_1.rb`:

```ruby
###
# Specify the default serializer used by `MessageEncryptor` and `MessageVerifier`
# instances.
#
# The legacy default is `:marshal`, which is a potential vector for
# deserialization attacks in cases where a message signing secret has been
# leaked.
#
# In Rails 7.1, the new default is `:json_allow_marshal` which serializes and
# deserializes with `ActiveSupport::JSON`, but can fall back to deserializing
# with `Marshal` so that legacy messages can still be read.
#
# In Rails 7.2, the default will become `:json` which serializes and
# deserializes with `ActiveSupport::JSON` only.
#
# Alternatively, you can choose `:message_pack` or `:message_pack_allow_marshal`,
# which serialize with `ActiveSupport::MessagePack`. `ActiveSupport::MessagePack`
# can roundtrip some Ruby types that are not supported by JSON, and may provide
# improved performance, but it requires the `msgpack` gem.
#
# For more information, see
# https://guides.rubyonrails.org/v7.1/configuring.html#config-active-support-message-serializer
#
# If you are performing a rolling deploy of a Rails 7.1 upgrade, wherein servers
# that have not yet been upgraded must be able to read messages from upgraded
# servers, first deploy without changing the serializer, then set the serializer
# in a subsequent deploy.
#++
# Rails.application.config.active_support.message_serializer = :json_allow_marshal
```

Tested that this fixed our app, although didn't add any tests for this change.